### PR TITLE
fix: create tab on arc browser

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,0 +1,10 @@
+import { searchMessaging } from "@/libs/messaging";
+
+export default defineBackground({
+  type: "module",
+  main() {
+    searchMessaging.onMessage("searchOnTab", async ({ data: { url } }) => {
+      await browser.tabs.create({ url });
+    });
+  },
+});

--- a/libs/messaging.ts
+++ b/libs/messaging.ts
@@ -1,0 +1,6 @@
+import { defineExtensionMessaging } from "@webext-core/messaging";
+
+type SearchMessaging = {
+  searchOnTab: (data: { url: string }) => void;
+};
+export const searchMessaging = defineExtensionMessaging<SearchMessaging>();

--- a/libs/search.ts
+++ b/libs/search.ts
@@ -1,4 +1,5 @@
 import type { WxtStorageItemType, extensionConfigState } from "./storage"
+import {searchMessaging} from './messaging'
 
 type ExtensionConfig = WxtStorageItemType<typeof extensionConfigState.storage>
 
@@ -52,18 +53,16 @@ const findFilter = (
 	return filter || fallbackFilter
 }
 
-export const executeSearch = (
-	config: ExtensionConfig,
-	currentTabUrl: string,
-	selectedText: string,
+export const executeSearch = async (
+  config: ExtensionConfig,
+  currentTabUrl: string,
+  selectedText: string
 ) => {
-	if (!selectedText) return
+  if (!selectedText) return
 
-	const target = findFilter(config, currentTabUrl).urlGenerator(selectedText)
-	if (typeof window !== "undefined") {
-		window.open(target, "_blank")
-	} else {
-		browser.tabs.create({ url: target })
-	}
-	console.info("executeSearch:", currentTabUrl, selectedText, target)
-}
+  const target = findFilter(config, currentTabUrl).urlGenerator(selectedText)
+
+  await searchMessaging.sendMessage("searchOnTab", { url: target })
+
+  console.info("executeSearch:", currentTabUrl, selectedText, target)
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@tsparticles/engine": "^3.5.0",
 		"@tsparticles/react": "^3.0.0",
 		"@tsparticles/slim": "^3.5.0",
+		"@webext-core/messaging": "^1.4.0",
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"es-toolkit": "^1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@tsparticles/slim':
         specifier: ^3.5.0
         version: 3.5.0
+      '@webext-core/messaging':
+        specifier: ^1.4.0
+        version: 1.4.0
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -1122,6 +1125,9 @@ packages:
 
   '@webext-core/match-patterns@1.0.3':
     resolution: {integrity: sha512-NY39ACqCxdKBmHgw361M9pfJma8e4AZo20w9AY+5ZjIj1W2dvXC8J31G5fjfOGbulW9w4WKpT8fPooi0mLkn9A==}
+
+  '@webext-core/messaging@1.4.0':
+    resolution: {integrity: sha512-gzXQ13HfKR3Yrn9TnrvTC/5seA7uPFvaqxqNFBsFOOdSZa5LyXt58Rhym8BYXarkWUGp+fh8f6AYM3RYuNbS+A==}
 
   '@wxt-dev/module-react@1.1.1':
     resolution: {integrity: sha512-bRTHMogtT0AeyKkrHCHhfuPc8hZnbHMPAi9ynm9eRN+uH4IxSZ3rETI7qPz4dbJQua+2ci84/XyQXzw14X/1iA==}
@@ -2679,6 +2685,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  serialize-error@11.0.3:
+    resolution: {integrity: sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==}
+    engines: {node: '>=14.16'}
+
   set-value@4.1.0:
     resolution: {integrity: sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==}
     engines: {node: '>=11.0'}
@@ -2997,6 +3007,9 @@ packages:
   web-ext-run@0.2.1:
     resolution: {integrity: sha512-5D11VcjdGkA1/xax5UWL0YeAbDySKHzWFe6EpsoPNUMw5Uk9tKk9p6GUOfcaI5N7sINKfBMZYNsTBiu5dzJB9A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+
+  webextension-polyfill@0.10.0:
+    resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}
 
   webextension-polyfill@0.12.0:
     resolution: {integrity: sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==}
@@ -4026,6 +4039,11 @@ snapshots:
       is-potential-custom-element-name: 1.0.1
 
   '@webext-core/match-patterns@1.0.3': {}
+
+  '@webext-core/messaging@1.4.0':
+    dependencies:
+      serialize-error: 11.0.3
+      webextension-polyfill: 0.10.0
 
   '@wxt-dev/module-react@1.1.1(vite@5.4.0(@types/node@22.2.0))(wxt@0.19.10(@types/node@22.2.0)(rollup@4.20.0)(webpack-sources@3.2.3))':
     dependencies:
@@ -5614,6 +5632,10 @@ snapshots:
 
   semver@7.6.3: {}
 
+  serialize-error@11.0.3:
+    dependencies:
+      type-fest: 2.19.0
+
   set-value@4.1.0:
     dependencies:
       is-plain-object: 2.0.4
@@ -5962,6 +5984,8 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  webextension-polyfill@0.10.0: {}
 
   webextension-polyfill@0.12.0: {}
 


### PR DESCRIPTION
close #3 

Support for Arc. And the tab opening method change to `browser.tabs.create`. `browser.tabs.create` only works in the background, so it's necessary to use messages.

---

### Chrome 
https://github.com/user-attachments/assets/3740d682-d360-4fd0-8ae1-f19ff384dfbf  

### Firefox
https://github.com/user-attachments/assets/d5a69cda-794b-417f-a076-5689228dc1f7  

### Arc
https://github.com/user-attachments/assets/5f999cfc-9994-4e22-ac2c-4ed0b954610c 


